### PR TITLE
Found a problem when not all nodes had the TDMA interface, and solved it.

### DIFF
--- a/helper/tdma-helper.cc
+++ b/helper/tdma-helper.cc
@@ -276,18 +276,20 @@ TdmaHelper::Install (NodeContainer c) const
   NS_LOG_FUNCTION (this);
   NetDeviceContainer devices;
   NS_ASSERT (m_controller != 0);
+  uint32_t slotUserId = 0;
   for (NodeContainer::Iterator i = c.Begin (); i != c.End (); ++i)
     {
       Ptr<Node> node = *i;
       Ptr<TdmaNetDevice> device = CreateObject<TdmaNetDevice> ();
       Ptr<TdmaMac> mac = m_mac.Create<TdmaMac> ();
       mac->SetAddress (Mac48Address::Allocate ());
-      AssignTdmaSlots (mac,node->GetId ());
+      AssignTdmaSlots (mac,slotUserId);
       device->SetMac (mac);
       device->SetChannel (m_channel);
       device->SetTdmaController (m_controller);
       node->AddDevice (device);
       devices.Add (device);
+      slotUserId++;
     }
   return devices;
 }


### PR DESCRIPTION
Removed actual node id from slot allocation, to allow some nodes to not have the TDMA interface present and still allow the TDMA cycle to work. Introduced a simple iterator named slotUserId instead. It's the MAC pointer that is needed for the TDMA cycle to be successfully run, not the node id.